### PR TITLE
multiple code improvements: squid:S1197, squid:S2131, squid:S2325

### DIFF
--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/ConsoleProgressMonitorInputStream.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/ConsoleProgressMonitorInputStream.java
@@ -42,7 +42,7 @@ public class ConsoleProgressMonitorInputStream extends FilterInputStream {
     }
 
     @Override
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         int length =  super.read(b, 0, b.length);
         totalRead += length;
 
@@ -50,7 +50,7 @@ public class ConsoleProgressMonitorInputStream extends FilterInputStream {
 
         String percentageToPrint;
         if(percentage==100) {
-            percentageToPrint = "" + percentage;
+            percentageToPrint = Integer.toString(percentage);
         } else {
             percentageToPrint = (percentage < 10) ? "  " + percentage : " " + percentage;
         }

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/HumanOutput.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/HumanOutput.java
@@ -183,7 +183,7 @@ public class HumanOutput extends CliOutput{
         return new ConsoleProgressMonitorInputStream(maximum,in);
     }
 
-    private String fillWithEmptySpace(String txt, int totalChar){
+    private static String fillWithEmptySpace(String txt, int totalChar){
         StringBuilder b = new StringBuilder(txt);
         for(int i = 0; i < totalChar-txt.length();i++) {
             b.insert(0, ' ');

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/MetaDirectoryManager.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/MetaDirectoryManager.java
@@ -83,12 +83,12 @@ public class MetaDirectoryManager {
     }
 
     public void setIteration(String filePath, int iteration) throws IOException {
-        indexProps.setProperty(filePath + "." + ITERATION_PROP, iteration+"");
+        indexProps.setProperty(filePath + "." + ITERATION_PROP, Integer.toString(iteration));
         saveIndex();
     }
 
     public void setLastModifiedDate(String filePath, long lastModifiedDate) throws IOException {
-        indexProps.setProperty(filePath + "." + LAST_MODIFIED_DATE_PROP, lastModifiedDate+"");
+        indexProps.setProperty(filePath + "." + LAST_MODIFIED_DATE_PROP, Long.toString(lastModifiedDate));
         saveIndex();
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S2325 - "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S2325
Please let me know if you have any questions.
George Kankava
