### PR TITLE
multiple code improvements: squid:S2786, squid:S00116, squid:SwitchLastCaseIsDefaultCheck, squid:S1213

### DIFF
--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/CliOutput.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/CliOutput.java
@@ -44,7 +44,7 @@ import static com.docdoku.cli.helpers.CliOutput.formats.HUMAN;
  */
 public abstract class CliOutput {
 
-    public static enum formats{
+    public enum formats {
         HUMAN,
         JSON
     }

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/ConsoleProgressMonitorInputStream.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/ConsoleProgressMonitorInputStream.java
@@ -31,7 +31,7 @@ public class ConsoleProgressMonitorInputStream extends FilterInputStream {
 
     private long maximum;
     private long totalRead;
-    private PrintStream OUTPUT_STREAM = System.out;
+    private PrintStream outputStream = System.out;
     private int rotationChar;
 
     private static final char[] ROTATION = {'|','|','|','|','/','/','/','/','-','-','-','-','\\','\\','\\','\\'};
@@ -56,12 +56,12 @@ public class ConsoleProgressMonitorInputStream extends FilterInputStream {
         }
 
         if(length ==-1) {
-            OUTPUT_STREAM.println("\r" + "100%");
+            outputStream.println("\r" + "100%");
         }else {
             if(maximum!=-1) {
-                OUTPUT_STREAM.print("\r" + percentageToPrint + "% Total " + FileUtils.byteCountToDisplaySize(totalRead) + " " + ROTATION[rotationChar % ROTATION.length] + "      ");
+                outputStream.print("\r" + percentageToPrint + "% Total " + FileUtils.byteCountToDisplaySize(totalRead) + " " + ROTATION[rotationChar % ROTATION.length] + "      ");
             }else{
-                OUTPUT_STREAM.print("\r" + "     Total " + FileUtils.byteCountToDisplaySize(totalRead) + " " + ROTATION[rotationChar % ROTATION.length] + "      ");
+                outputStream.print("\r" + "     Total " + FileUtils.byteCountToDisplaySize(totalRead) + " " + ROTATION[rotationChar % ROTATION.length] + "      ");
             }
         }
 

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/FileHelper.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/FileHelper.java
@@ -201,6 +201,8 @@ public class FileHelper {
                 throw new LoginException(LangHelper.getLocalizedMessage("LoginError",locale));
             case 500:
                 throw new IOException(conn.getHeaderField("Reason-Phrase"));
+            default:
+                break;
         }
     }
 

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/JSONProgressMonitorInputStream.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/JSONProgressMonitorInputStream.java
@@ -30,7 +30,7 @@ public class JSONProgressMonitorInputStream extends FilterInputStream {
     private long maximum;
     private long totalRead;
     private int oldPercentage=-1;
-    private PrintStream OUTPUT_STREAM = System.out;
+    private PrintStream outputStream = System.out;
 
     public JSONProgressMonitorInputStream(long maximum, InputStream in){
         super(in);
@@ -44,7 +44,7 @@ public class JSONProgressMonitorInputStream extends FilterInputStream {
         int percentage = (int)((totalRead * 100.0f) / maximum);
 
         if(percentage > oldPercentage) {
-            OUTPUT_STREAM.println("{\"progress\":" + percentage + "}");
+            outputStream.println("{\"progress\":" + percentage + "}");
         }
 
         oldPercentage = percentage ;

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/LangHelper.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/LangHelper.java
@@ -28,6 +28,8 @@ public class LangHelper {
 
     private static final String BUNDLE_NAME = "com.docdoku.cli.i18n.LocalStrings";
 
+    private LangHelper() {}
+
     public static String getLocalizedMessage(String key, String userLogin) throws IOException {
         return getLocalizedMessage(key, new AccountsManager().getUserLocale(userLogin));
     }
@@ -35,9 +37,6 @@ public class LangHelper {
     public static String getLocalizedMessage(String key, Locale locale){
         ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, locale);
         return bundle.getString(key);
-    }
-
-    private LangHelper() {
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2786 - Nested "enum"s should not be declared static.
squid:S00116 - Field names should comply with a naming convention.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2786
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava