### PR TITLE
multiple code improvements: squid:S1213, squid:S00116

### DIFF
--- a/docdoku-cli/src/main/java/com/docdoku/cli/MainCommand.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/MainCommand.java
@@ -35,9 +35,12 @@ import java.util.Arrays;
 
 public class MainCommand {
 
-
     private static final String PART = "part";
     private static final String DOCUMENT = "document";
+
+    private MainCommand() {
+        super();
+    }
 
     /**
      * Main function wrapper
@@ -174,10 +177,6 @@ public class MainCommand {
         } catch (Exception e) {
             execCommand(new HelpCommand(), args);
         }
-    }
-
-    private MainCommand() {
-        super();
     }
 
     private static void execCommand(CommandLine cl, String[] args) {

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/HumanOutput.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/HumanOutput.java
@@ -44,15 +44,15 @@ import java.util.Locale;
 public class HumanOutput extends CliOutput{
 
     private Locale locale;
-    private PrintStream ERROR_STREAM = System.err;
-    private PrintStream OUTPUT_STREAM = System.out;
+    private PrintStream errorStream = System.err;
+    private PrintStream outputStream = System.out;
     public HumanOutput(Locale pLocale) {
         locale = pLocale;
     }
 
     @Override
     public void printException(Exception e) {
-        ERROR_STREAM.println(e.getMessage());
+        errorStream.println(e.getMessage());
         if(e instanceof CmdLineException){
             printUsage();
         }
@@ -61,50 +61,50 @@ public class HumanOutput extends CliOutput{
     @Override
     public void printCommandUsage(CommandLine cl) throws IOException {
         CmdLineParser parser = new CmdLineParser(cl);
-        OUTPUT_STREAM.println(cl.getDescription());
-        OUTPUT_STREAM.println();
-        parser.printUsage(OUTPUT_STREAM);
-        OUTPUT_STREAM.println();
+        outputStream.println(cl.getDescription());
+        outputStream.println();
+        parser.printUsage(outputStream);
+        outputStream.println();
     }
 
     @Override
     public void printUsage() {
-        ERROR_STREAM.println(LangHelper.getLocalizedMessage("Usage",locale));
-        ERROR_STREAM.println();
+        errorStream.println(LangHelper.getLocalizedMessage("Usage",locale));
+        errorStream.println();
         printAvailableCommands();
-        ERROR_STREAM.println();
-        ERROR_STREAM.println(LangHelper.getLocalizedMessage("AdditionalInfos",locale));
+        errorStream.println();
+        errorStream.println(LangHelper.getLocalizedMessage("AdditionalInfos",locale));
     }
 
     private void printAvailableCommands(){
-        ERROR_STREAM.println(LangHelper.getLocalizedMessage("AvailableCommands",locale) +":");
-        ERROR_STREAM.println("   checkin (ci)");
-        ERROR_STREAM.println("   checkout (co)");
-        ERROR_STREAM.println("   create (cr)");
-        ERROR_STREAM.println("   get");
-        ERROR_STREAM.println("   help (?, h)");
-        ERROR_STREAM.println("   put");
-        ERROR_STREAM.println("   status (stat, st)");
-        ERROR_STREAM.println("   undocheckout (uco)");
-        ERROR_STREAM.println();
-        ERROR_STREAM.println(LangHelper.getLocalizedMessage("InstructionCommands",locale));
+        errorStream.println(LangHelper.getLocalizedMessage("AvailableCommands",locale) +":");
+        errorStream.println("   checkin (ci)");
+        errorStream.println("   checkout (co)");
+        errorStream.println("   create (cr)");
+        errorStream.println("   get");
+        errorStream.println("   help (?, h)");
+        errorStream.println("   put");
+        errorStream.println("   status (stat, st)");
+        errorStream.println("   undocheckout (uco)");
+        errorStream.println();
+        errorStream.println(LangHelper.getLocalizedMessage("InstructionCommands",locale));
     }
 
     @Override
     public void printInfo(String s) {
-        OUTPUT_STREAM.println(s);
+        outputStream.println(s);
     }
 
     @Override
     public void printWorkspaces(Workspace[] workspaces) {
         for(Workspace workspace:workspaces){
-            OUTPUT_STREAM.println(workspace.getId());
+            outputStream.println(workspace.getId());
         }
     }
 
     @Override
     public void printPartRevisionsCount(int partRevisionsCount) {
-        OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("Count",locale) + " : " + partRevisionsCount);
+        outputStream.println(LangHelper.getLocalizedMessage("Count",locale) + " : " + partRevisionsCount);
     }
 
     @Override
@@ -117,11 +117,11 @@ public class HumanOutput extends CliOutput{
     @Override
     public void printBaselines(List<ProductBaseline> productBaselines) {
         if(productBaselines.isEmpty()){
-            OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("NoBaseline",locale));
+            outputStream.println(LangHelper.getLocalizedMessage("NoBaseline",locale));
             return;
         }
         for(ProductBaseline productBaseline : productBaselines) {
-            OUTPUT_STREAM.println("#" + productBaseline.getId() + " : " + productBaseline.getName());
+            outputStream.println("#" + productBaseline.getId() + " : " + productBaseline.getName());
         }
     }
 
@@ -141,22 +141,22 @@ public class HumanOutput extends CliOutput{
     @Override
     public void printConversion(Conversion conversion) {
         if(conversion.isSucceed()){
-            OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("ConversionSucceed",locale));
+            outputStream.println(LangHelper.getLocalizedMessage("ConversionSucceed",locale));
         }else if(conversion.isPending()){
-            OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("ConversionInProgress",locale));
+            outputStream.println(LangHelper.getLocalizedMessage("ConversionInProgress",locale));
         } else{
-            OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("ConversionFailed",locale));
+            outputStream.println(LangHelper.getLocalizedMessage("ConversionFailed",locale));
         }
-        OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("ConversionStarted",locale) + " : " + conversion.getStartDate());
-        OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("ConversionEnded",locale) + " : " + conversion.getEndDate());
+        outputStream.println(LangHelper.getLocalizedMessage("ConversionStarted",locale) + " : " + conversion.getStartDate());
+        outputStream.println(LangHelper.getLocalizedMessage("ConversionEnded",locale) + " : " + conversion.getEndDate());
     }
 
     @Override
     public void printAccount(Account account) throws JSONException {
-        OUTPUT_STREAM.println(account.getLogin());
-        OUTPUT_STREAM.println(account.getEmail());
-        OUTPUT_STREAM.println(account.getLanguage());
-        OUTPUT_STREAM.println(account.getTimeZone());
+        outputStream.println(account.getLogin());
+        outputStream.println(account.getEmail());
+        outputStream.println(account.getLanguage());
+        outputStream.println(account.getTimeZone());
     }
 
     @Override
@@ -174,7 +174,7 @@ public class HumanOutput extends CliOutput{
     @Override
     public void printFolders(String[] folders) {
         for (String folder : folders) {
-            OUTPUT_STREAM.println(folder);
+            outputStream.println(folder);
         }
     }
 
@@ -197,7 +197,7 @@ public class HumanOutput extends CliOutput{
         String revision = fillWithEmptySpace(pr.getVersion(),revColSize);
         DateFormat df = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.SHORT, Locale.US);
 
-        OUTPUT_STREAM.println("# "+pr.getPartMasterNumber());
+        outputStream.println("# "+pr.getPartMasterNumber());
 
         String checkout = "";
         if(pr.isCheckedOut()){
@@ -210,7 +210,7 @@ public class HumanOutput extends CliOutput{
                     + " "
                     + df.format(pr.getCheckOutDate());
         }
-        OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("Revision",locale) + " " + revision + checkout);
+        outputStream.println(LangHelper.getLocalizedMessage("Revision",locale) + " " + revision + checkout);
         int iteColSize = (pr.getLastIteration().getIteration() +"").length();
         int dateColSize=0;
         int authorColSize=0;
@@ -222,7 +222,7 @@ public class HumanOutput extends CliOutput{
         for(PartIteration pi:pr.getPartIterations()){
             printIterationStatus(pi, iteColSize, dateColSize +1, authorColSize+1);
         }
-        OUTPUT_STREAM.println("");
+        outputStream.println("");
     }
 
     private void printIterationStatus(PartIteration pi, int iteColSize, int dateColSize, int authorColSize){
@@ -231,7 +231,7 @@ public class HumanOutput extends CliOutput{
         String date = fillWithEmptySpace(df.format(pi.getCreationDate()), dateColSize);
         String author = fillWithEmptySpace(pi.getAuthor()+"", authorColSize);
         String note = pi.getIterationNote()==null?"":pi.getIterationNote();
-        OUTPUT_STREAM.println(iteration + " |" + date + " |" + author + " | " + note);
+        outputStream.println(iteration + " |" + date + " |" + author + " | " + note);
     }
 
 
@@ -240,7 +240,7 @@ public class HumanOutput extends CliOutput{
         String revision = fillWithEmptySpace(dr.getVersion(),revColSize);
         DateFormat df = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.SHORT, Locale.US);
 
-        OUTPUT_STREAM.println("# " + dr.getDocumentMasterId());
+        outputStream.println("# " + dr.getDocumentMasterId());
 
         String checkout = "";
         if(dr.isCheckedOut()){
@@ -253,7 +253,7 @@ public class HumanOutput extends CliOutput{
                     + " "
                     + df.format(dr.getCheckOutDate());
         }
-        OUTPUT_STREAM.println(LangHelper.getLocalizedMessage("Revision",locale) + " " + revision + checkout);
+        outputStream.println(LangHelper.getLocalizedMessage("Revision",locale) + " " + revision + checkout);
         int iteColSize = (dr.getLastIteration().getIteration() +"").length();
         int dateColSize=0;
         int authorColSize=0;
@@ -265,7 +265,7 @@ public class HumanOutput extends CliOutput{
         for(DocumentIteration di:dr.getDocumentIterations()){
             printIterationStatus(di, iteColSize, dateColSize +1, authorColSize+1);
         }
-        OUTPUT_STREAM.println("");
+        outputStream.println("");
     }
 
     private void printIterationStatus(DocumentIteration di, int iteColSize, int dateColSize, int authorColSize){
@@ -274,6 +274,6 @@ public class HumanOutput extends CliOutput{
         String date = fillWithEmptySpace(df.format(di.getCreationDate()), dateColSize);
         String author = fillWithEmptySpace(di.getAuthor()+"", authorColSize);
         String note = di.getRevisionNote()==null?"" : di.getRevisionNote();
-        OUTPUT_STREAM.println(iteration + " |" + date + " |" + author + " | " + note);
+        outputStream.println(iteration + " |" + date + " |" + author + " | " + note);
     }
 }

--- a/docdoku-cli/src/main/java/com/docdoku/cli/helpers/JSONOutput.java
+++ b/docdoku-cli/src/main/java/com/docdoku/cli/helpers/JSONOutput.java
@@ -44,8 +44,8 @@ import java.util.logging.Logger;
 public class JSONOutput extends CliOutput {
 
     private static final Logger LOGGER = Logger.getLogger(JSONOutput.class.getName());
-    private PrintStream ERROR_STREAM = System.err;
-    private PrintStream OUTPUT_STREAM = System.out;
+    private PrintStream errorStream = System.err;
+    private PrintStream outputStream = System.out;
 
     public JSONOutput() {
     }
@@ -58,7 +58,7 @@ public class JSONOutput extends CliOutput {
         } catch (JSONException e1) {
             LOGGER.log(Level.FINEST,null,e1);
         }
-        ERROR_STREAM.println(jsonObj.toString());
+        errorStream.println(jsonObj.toString());
     }
 
     @Override
@@ -73,12 +73,12 @@ public class JSONOutput extends CliOutput {
         } catch (JSONException e) {
             LOGGER.log(Level.FINEST,null,e);
         }
-        OUTPUT_STREAM.println(jsonObj.toString());
+        outputStream.println(jsonObj.toString());
     }
 
     @Override
     public void printUsage() {
-        ERROR_STREAM.println("{\"usage\":\"TODO\"}");
+        errorStream.println("{\"usage\":\"TODO\"}");
     }
 
     @Override
@@ -89,7 +89,7 @@ public class JSONOutput extends CliOutput {
         } catch (JSONException e1) {
             LOGGER.log(Level.FINEST,null,e1);
         }
-        OUTPUT_STREAM.println(jsonObj.toString());
+        outputStream.println(jsonObj.toString());
     }
 
     @Override
@@ -102,7 +102,7 @@ public class JSONOutput extends CliOutput {
                 LOGGER.log(Level.FINEST,null,e);
             }
         }
-        OUTPUT_STREAM.println(wks.toString());
+        outputStream.println(wks.toString());
     }
 
     @Override
@@ -113,7 +113,7 @@ public class JSONOutput extends CliOutput {
         } catch (JSONException e) {
             LOGGER.log(Level.FINEST,null,e);
         }
-        OUTPUT_STREAM.println(jsonObject.toString());
+        outputStream.println(jsonObject.toString());
     }
 
     @Override
@@ -122,7 +122,7 @@ public class JSONOutput extends CliOutput {
         for (PartRevision partRevision : partRevisions) {
             jsonArray.put(getPartRevision(partRevision, 0L));
         }
-        OUTPUT_STREAM.println(jsonArray.toString());
+        outputStream.println(jsonArray.toString());
     }
 
     @Override
@@ -139,12 +139,12 @@ public class JSONOutput extends CliOutput {
                 LOGGER.log(Level.FINEST,null,e);
             }
         }
-        OUTPUT_STREAM.println(jsonArray.toString());
+        outputStream.println(jsonArray.toString());
     }
 
     @Override
     public void printPartRevision(PartRevision pr, long lastModified) {
-        OUTPUT_STREAM.println(getPartRevision(pr, lastModified));
+        outputStream.println(getPartRevision(pr, lastModified));
     }
 
     @Override
@@ -160,7 +160,7 @@ public class JSONOutput extends CliOutput {
             LOGGER.log(Level.FINEST,null,e);
         }
 
-        OUTPUT_STREAM.println(getPartRevision(pm.getLastRevision(), lastModified));
+        outputStream.println(getPartRevision(pm.getLastRevision(), lastModified));
     }
 
     @Override
@@ -170,7 +170,7 @@ public class JSONOutput extends CliOutput {
         cv.put("succeed", conversion.isSucceed());
         cv.put("startDate", conversion.getStartDate());
         cv.put("endDate", conversion.getEndDate());
-        OUTPUT_STREAM.println(cv.toString());
+        outputStream.println(cv.toString());
     }
 
     @Override
@@ -180,12 +180,12 @@ public class JSONOutput extends CliOutput {
         cv.put("language", account.getLanguage());
         cv.put("email", account.getEmail());
         cv.put("timezone", account.getTimeZone());
-        OUTPUT_STREAM.println(cv.toString());
+        outputStream.println(cv.toString());
     }
 
     @Override
     public void printDocumentRevision(DocumentRevision documentRevision, long lastModified) {
-        OUTPUT_STREAM.println(getDocumentRevision(documentRevision, lastModified));
+        outputStream.println(getDocumentRevision(documentRevision, lastModified));
     }
 
     @Override
@@ -194,7 +194,7 @@ public class JSONOutput extends CliOutput {
         for (DocumentRevision documentRevision : documentRevisions) {
             jsonArray.put(getDocumentRevision(documentRevision, 0L));
         }
-        OUTPUT_STREAM.println(jsonArray.toString());
+        outputStream.println(jsonArray.toString());
     }
 
     @Override
@@ -203,7 +203,7 @@ public class JSONOutput extends CliOutput {
         for (String folder : folders) {
             jsonArray.put(folder);
         }
-        OUTPUT_STREAM.println(jsonArray.toString());
+        outputStream.println(jsonArray.toString());
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
squid:S00116 Field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00116
Please let me know if you have any questions.
George Kankava
